### PR TITLE
Update request for passcode auth

### DIFF
--- a/dvach-browser/Models/DVBNetworking.m
+++ b/dvach-browser/Models/DVBNetworking.m
@@ -102,7 +102,7 @@ static NSString * const NO_CAPTCHA_ANSWER_CODE = @"disabled";
                            @"usercode":passcode
                            };
 
-  [manager POST:requestAddress parameters:params success:^(AFHTTPRequestOperation *operation, id responseObject)
+  [manager GET:requestAddress parameters:params success:^(AFHTTPRequestOperation *operation, id responseObject)
    {
      NSString *usercode = [self getUsercodeFromCookies];
      completion(usercode);
@@ -120,7 +120,7 @@ static NSString * const NO_CAPTCHA_ANSWER_CODE = @"disabled";
 - (NSString *)getUsercodeFromCookies {
   NSArray *cookiesArray = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookies];
   for (NSHTTPCookie *cookie in cookiesArray) {
-    BOOL isThisUsercodeCookie = [cookie.name isEqualToString:@"usercode_nocaptcha"];
+    BOOL isThisUsercodeCookie = [cookie.name isEqualToString:@"passcode_auth"];
     if (isThisUsercodeCookie) {
       NSString *usercode = cookie.value;
       NSLog(@"usercode success");


### PR DESCRIPTION
### Background
Passcode auth had some changes and wasn't working with the current implementation

### What has been done
1. Reverse engineered request from https://2ch.hk/2ch/
2. Updated auth request to GET
3. Update cookie name to `passcode_auth`

### How to test
1. Set a valid passcode in the app settings (you can test it in https://2ch.hk/2ch/)
2. Start the app
3. Make sure that the cookie value is correct
4. Make sure that you can post/reply without the captcha.